### PR TITLE
merge[#8]: fusionar rama feature-workflow-k8s a develop

### DIFF
--- a/docs/workflows.yaml
+++ b/docs/workflows.yaml
@@ -5,3 +5,6 @@ workflows:
   - event: message_received
     queue: redis://redis:6379/0
     action: python /app/src/notify.py
+  - event: k8s_deploy
+    manifest: /app/k8s/<manifest>
+    action: python /app/src/k8s_deploy.py <manifest>

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,5 @@ redis==6.2.0
 tomli==2.2.1
 typing_extensions==4.14.0
 watchdog==6.0.0
+kubernetes==30.1.0
+jsonschema==4.22.0

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1,0 +1,51 @@
+import pytest
+import yaml
+import jsonschema
+from jsonschema import validate
+
+# Definimos el esquema afuera para poder reutilizarlo en los tests
+schema = {
+    "type": "object",
+    "properties": {
+        "workflows": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "event": {"type": "string", "enum": ["file_created", "message_received", "k8s_deploy"]},
+                    "path": {"type": "string"},
+                    "queue": {"type": "string"},
+                    "manifest": {"type": "string"},
+                    "action": {"type": "string"},
+                },
+                "required": ["event", "action"],
+                "if": {"properties": {"event": {"const": "file_created"}}},
+                "then": {"required": ["path"]},
+                "else": {
+                    "if": {"properties": {"event": {"const": "message_received"}}},
+                    "then": {"required": ["queue"]}
+                }
+            }
+        }
+    },
+    "required": ["workflows"]
+}
+
+def test_cargar_workflows_valido():
+    with open("/app/docs/workflows.yaml") as f:
+        workflows = yaml.safe_load(f)
+    
+    validate(instance=workflows, schema=schema)
+    assert len(workflows["workflows"]) == 3
+    assert workflows["workflows"][2]["event"] == "k8s_deploy"
+    assert "<manifest>" in workflows["workflows"][2]["action"]
+    assert "manifest" in workflows["workflows"][2]
+
+def test_cargar_workflows_invalido():
+    invalid_yaml = """
+    workflows:
+      - event: invalid_event
+        action: echo test
+    """
+    with pytest.raises(jsonschema.ValidationError):
+        validate(instance=yaml.safe_load(invalid_yaml), schema=schema)


### PR DESCRIPTION
- Se extiende el archivo workflows.yaml para soportar el evento k8s_deploy para definir acciones de despliegue en Kubernetes
- Se actualiza la prueba de contrato en test/test_workflows.py para validar la nueva estructura y asegurar que el YAML cumpla con el esquema esperado
- Se actualizo requirements.txt con las dos dependencias necesarias kubernetes==30.1.0 y jsonschema==4.22.0

Con esto cumplimos con el issue [#16 ]

