### PR TITLE
Merge[#28]: Fusionar fix-conflictos-flujos a develop

### DIFF
--- a/docs/workflows.yaml
+++ b/docs/workflows.yaml
@@ -2,13 +2,17 @@ workflows:
   - id: process_file
     event: file_created
     path: /app/data
+    action_type: script
     action: /app/scripts/process_data.sh <file>
+    recursive: false
   - id: notify_message
     event: message_received
     queue: redis://redis:6379/0
+    action_type: script
     action: python /app/src/notify.py
   - id: k8s_nginx
-    event: k8s_deploy
+    event: file_created
+    path: /app/data/k8s 
+    action_type: kubernetes
     manifest: /app/k8s/nginx-deployment.yaml
-    action: python /app/src/k8s_deploy.py <manifest>
     depends_on: ['process_file']

--- a/src/event_engine.py
+++ b/src/event_engine.py
@@ -6,7 +6,10 @@ import yaml
 import redis
 import logging
 import threading
+import subprocess
 from src.workflow_deps import check_dependencies, update_workflow_state
+from src.workflow_deps import deploy
+
 
 # Configura el sistema para escribir un log en un archivo y en la consola
 logging.basicConfig(
@@ -31,35 +34,35 @@ class FileEventHandler(watchdog.events.FileSystemEventHandler):
         if not event.is_directory:
             logger.info(f"Archivo creado: {event.src_path}")
             for wf in self.workflows:
-                if wf["event"] == "file_created" and event.src_path.startswith(
-                    wf["path"]
-                ):
-                    if check_dependencies(wf):
-                        action = wf["action"].replace("<file>", event.src_path)
-                        logger.info(f"Ejecutando acción: {action}")
-                        exit_code = os.system(action)
-                        workflow_id = wf.get("id", "")
-                        status = "success" if exit_code == 0 else "failed"
-                        update_workflow_state(workflow_id, status)
-                    else:
-                        logger.warning(f"Dependencias no cumplidas para workflow {wf.get('id', '')}")
-                elif wf["event"] == "k8s_deploy" and event.src_path.startswith(wf.get("path", "")):
-                    if check_dependencies(wf):
-                        action = wf["action"].replace("<manifest>", wf["manifest"])
-                        logger.info(f"Ejecutando acción: {action}")
-                        exit_code = os.system(action)
-                        workflow_id = wf.get("id", "")
-                        status = "success" if exit_code == 0 else "failed"
-                        update_workflow_state(workflow_id, status)
-                    else:
-                        logger.warning(f"Dependencias no cumplidas para workflow {wf.get('id', '')}")
+                if wf["event"] == "file_created" :
+                    esta_en_directorio = event.src_path.startswith(wf["path"])
+                    es_recursivo = wf.get("recursive", True)
+                    es_directorio_exacto = os.path.dirname(event.src_path) == wf["path"].rstrip("/")
+                    if esta_en_directorio and (es_recursivo or es_directorio_exacto):
+                        if check_dependencies(wf):
+                            if wf.get("action_type") == "script":
+                                action = wf["action"].replace("<file>", event.src_path)
+                                logger.info(f"Ejecutando acción: {action}")
+                                result = subprocess.run(action, shell=True, capture_output=True, text=True)
+                                status = "success" if result.returncode == 0 else "failed"
+                                update_workflow_state(wf.get("id",""), status)
+                            elif wf.get("action_type") == "kubernetes":
+                                logger.info(f"Ejecutando acción de Kubernetes: {wf['manifest']}")
+                                succes = deploy(wf["manifest"])
+                                status = "success" if succes else "failed"
+                                update_workflow_state(wf.get("id", ""), status)
+                        else:
+                            logger.warning(f"Dependencias no cumplidas para workflow {wf.get('id', '')}")
 
 
 # Carga la configuracion de workflows desde un YAML
 def load_workflows(config_path):
     try:
         with open(config_path) as f:
-            return yaml.safe_load(f)["workflows"]
+            workflows = yaml.safe_load(f)["workflows"]
+            for wf in workflows:
+                wf["id"] = wf.get("id", f"workflow_{id(wf)}")
+            return workflows
     except FileNotFoundError:
         logger.error(f"No se encontro {config_path}")
         exit(1)
@@ -81,7 +84,9 @@ def listen_redis(queue, workflows):
                 for wf in workflows:
                     if wf["event"] == "message_received" and wf["queue"] == queue:
                         logger.info(f"Ejecutando accion: {wf['action']}")
-                        os.system(wf["action"])
+                        result = subprocess.run(wf["action"], shell=True, capture_output=True, text=True)
+                        status = "success" if result.returncode == 0 else "failed"
+                        update_workflow_state(wf.get("id", ""), status)
     except redis.RedisError as e:
         logger.error(f"Error de Redis: {e}")
         exit(1)
@@ -90,19 +95,27 @@ def listen_redis(queue, workflows):
 if __name__ == "__main__": # pragma: no cover
     data_dir = "/app/data"
     config_path = "/app/docs/workflows.yaml"
+    redis_url = "redis://localhost:6379/0"
+
     if not os.path.exists(data_dir):
         logger.error(f"Directorio  {data_dir} no existe")
         exit(1)
     if not os.path.exists(config_path):
         logger.error(f"No se encontro {config_path} ")
         exit(1)
+
     workflows = load_workflows(config_path)
+
     # File observer
     observer = PollingObserver()
-    observer.schedule(FileEventHandler(workflows), path=data_dir, recursive=False)
+    for wf in workflows:
+        if wf["event"] == "file_created":
+            recursive = wf.get("recursive", True)
+            observer.schedule(FileEventHandler(workflows), path=wf["path"], recursive=recursive)
     observer.start()
     time.sleep(2)
     logger.info(f"Monitoreando: {data_dir}")
+
     # Redis listener
     for wf in workflows:
         if wf["event"] == "message_received":

--- a/src/workflow_deps.py
+++ b/src/workflow_deps.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 STATE_FILE = "/app/data/workflow_state.json"
 
 def init_state():
+    os.makedirs(os.path.dirname(STATE_FILE), exist_ok=True)
     if not os.path.exists(STATE_FILE):
         with open(STATE_FILE, 'w') as f:
             json.dump({}, f)
@@ -26,10 +27,11 @@ def update_workflow_state(workflow_id, status):
             state = json.load(f)
         state[workflow_id] = status
         with open(STATE_FILE, 'w') as f:
-            json.dump(state, f)
+            json.dump(state, f, indent=2)
         logger.info(f"Estado actualizado: {workflow_id} -> {status}")
     except Exception as e:
         logger.error(f"Error actualizando estado: {e}")
+        raise
 
 def check_dependencies(workflow):
     init_state()


### PR DESCRIPTION
Se siguieren los requerimientos establecidos en el issue [#28]

- [x] Actualizar `docs/workflows.yaml` para incluir `recursive: false` en el flujo `process_file`.
- [x] Modificar `src/event_engine.py` para respetar el campo `recursive` y configurar un observador por flujo con su respectivo `path`.
- [x] Verificar que `touch data/k8s/trigger.txt` activa el flujo `k8s_nginx` y no `process_file`.
- [x] Comprobar que `kubectl get pods` muestra `nginx-deployment` y `kubectl get services` muestra `nginx-service` tras ejecutar `touch data/k8s/trigger.txt`.