### PR TITLE
merge[#30]: Fusionar rama test-pruebas-unitarias-sprint-3 a develop

### DIFF
--- a/tests/test_k8s_deploy.py
+++ b/tests/test_k8s_deploy.py
@@ -1,97 +1,257 @@
 import pytest
-from unittest.mock import patch, mock_open, MagicMock
-from src import k8s_deploy
+from unittest.mock import patch, MagicMock, mock_open
 import yaml
+from kubernetes.client.rest import ApiException
+from src import k8s_deploy
+
+# contenido YAML basado en nginx-deployment.yaml
+NGINX_YAML = """
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service
+  namespace: default
+spec:
+  selector:
+    app: nginx
+  ports:
+  - port: 80
+    targetPort: 80
+  type: ClusterIP
+"""
 
 
-# test para load_manifest
+# test  load_manifest
 def test_carga_manifest_correctamente():
-    contenido_yaml = "kind: Deployment\nmetadata:\n  name: mi-deploy\n"
-    with patch("builtins.open", mock_open(read_data=contenido_yaml)):
-        resultado = k8s_deploy.load_manifest("ruta/ficticia.yaml")
-        assert resultado["kind"] == "Deployment"
-        assert resultado["metadata"]["name"] == "mi-deploy"
+    # simula archivo abierto con contenido de nginx-deployment.yaml
+    with patch("builtins.open", mock_open(read_data=NGINX_YAML)):
+        resultado = k8s_deploy.load_manifest("k8s/nginx-deployment.yaml")
+        # verifica que se cargaron dos documentos
+        assert len(resultado) == 2
+        # verifica Deployment
+        assert resultado[0]["kind"] == "Deployment"
+        assert resultado[0]["metadata"]["name"] == "nginx-deployment"
+        assert resultado[0]["spec"]["replicas"] == 1
+        assert resultado[0]["spec"]["selector"]["matchLabels"]["app"] == "nginx"
+        # verifica Service
+        assert resultado[1]["kind"] == "Service"
+        assert resultado[1]["metadata"]["name"] == "nginx-service"
+        assert resultado[1]["spec"]["ports"][0]["port"] == 80
+        assert resultado[1]["spec"]["type"] == "ClusterIP"
 
 
+# test  error al cargar manifiesto no encontrado
 def test_error_manifest_no_encontrado():
+    # simula error de archivo no encontrado
     with patch("builtins.open", side_effect=FileNotFoundError):
         with pytest.raises(FileNotFoundError):
             k8s_deploy.load_manifest("inexistente.yaml")
 
 
+# test  error al cargar YAML invalido
 def test_error_yaml_invalido():
+    # contenido YAML invalido
     contenido_invalido = "key: : value: otro"
+    # simula archivo abierto con contenido invalido
     with patch("builtins.open", mock_open(read_data=contenido_invalido)):
         with pytest.raises(yaml.YAMLError):
             k8s_deploy.load_manifest("manifesto_invalido.yaml")
 
 
-# tests para apply_manifest
-@patch("src.k8s_deploy.client.AppsV1Api")
-@patch("src.k8s_deploy.config.load_kube_config")
-def test_aplica_manifest_deployment(mock_config, mock_api_class):
+# test  aplicar manifiesto de tipo Deployment
+@patch("kubernetes.client.AppsV1Api")
+@patch("kubernetes.client.CoreV1Api")
+@patch("kubernetes.config.load_kube_config")
+def test_aplica_manifest_deployment(mock_config, mock_core_api, mock_apps_api):
+    # manifiesto de prueba basado en nginx-deployment.yaml
     manifest = {
         "kind": "Deployment",
-        "metadata": {"name": "mi-deploy", "namespace": "default"}
+        "metadata": {"name": "nginx-deployment", "namespace": "default"},
+        "spec": {"replicas": 1, "selector": {"matchLabels": {"app": "nginx"}}}
     }
+    # configura mock  API
     mock_api = MagicMock()
-    mock_api_class.return_value = mock_api
+    mock_apps_api.return_value = mock_api
+    # simula que el despliegue no existe (404)
+    mock_api.read_namespaced_deployment.side_effect = ApiException(status=404)
+    # ejecuta funcion
     resultado = k8s_deploy.apply_manifest(manifest)
+    # verifica resultado
     assert resultado is True
-    mock_api.create_namespaced_deployment.assert_called_once()
+    # verifica que se llamo a create_namespaced_deployment
+    mock_api.create_namespaced_deployment.assert_called_once_with("default", manifest)
+    # verifica que no se llamo a replace
+    mock_api.replace_namespaced_deployment.assert_not_called()
 
 
-@patch("src.k8s_deploy.client.AppsV1Api")
-@patch("src.k8s_deploy.config.load_kube_config")
-def test_aplica_manifest_tipo_no_soportado(mock_config, mock_api_class):
-    manifest = {"kind": "Service"}
-    resultado = k8s_deploy.apply_manifest(manifest)
-    assert resultado is False
-
-
-@patch("src.k8s_deploy.client.AppsV1Api", side_effect=k8s_deploy.ApiException("Error API"))
-@patch("src.k8s_deploy.config.load_kube_config")
-def test_error_api_al_aplicar_manifest(mock_config, mock_api_class):
-    manifest = {"kind": "Deployment", "metadata": {"name": "x"}}
-    resultado = k8s_deploy.apply_manifest(manifest)
-    assert resultado is False
-
-
-# tests para check_deployment_status
-@patch("src.k8s_deploy.client.AppsV1Api")
-@patch("src.k8s_deploy.config.load_kube_config")
-def test_deployment_listo(mock_config, mock_api_class):
-    mock_deploy = MagicMock()
-    mock_deploy.status.ready_replicas = 3
-    mock_deploy.spec.replicas = 3
+# test  aplicar manifiesto de tipo Service
+@patch("kubernetes.client.AppsV1Api")
+@patch("kubernetes.client.CoreV1Api")
+@patch("kubernetes.config.load_kube_config")
+def test_aplica_manifest_service(mock_config, mock_core_api, mock_apps_api):
+    # manifiesto de prueba basado en nginx-deployment.yaml
+    manifest = {
+        "kind": "Service",
+        "metadata": {"name": "nginx-service", "namespace": "default"},
+        "spec": {"ports": [{"port": 80, "targetPort": 80}], "type": "ClusterIP"}
+    }
+    # configura mock  API
     mock_api = MagicMock()
-    mock_api.read_namespaced_deployment.return_value = mock_deploy
-    mock_api_class.return_value = mock_api
-    assert k8s_deploy.check_deployment_status("mi-deploy") is True
+    mock_core_api.return_value = mock_api
+    # simula que el servicio no existe (404)
+    mock_api.read_namespaced_service.side_effect = ApiException(status=404)
+    # ejecuta funcion
+    resultado = k8s_deploy.apply_manifest(manifest)
+    # verifica resultado
+    assert resultado is True
+    # verifica que se llamo a create_namespaced_service
+    mock_api.create_namespaced_service.assert_called_once_with("default", manifest)
+    # verifica que no se llamo a replace
+    mock_api.replace_namespaced_service.assert_not_called()
 
 
-@patch("src.k8s_deploy.client.AppsV1Api")
-@patch("src.k8s_deploy.config.load_kube_config")
-def test_deployment_no_listo(mock_config, mock_api_class):
+# test  aplicar manifiesto de tipo Deployment existente
+@patch("kubernetes.client.AppsV1Api")
+@patch("kubernetes.client.CoreV1Api")
+@patch("kubernetes.config.load_kube_config")
+def test_aplica_manifest_deployment_existente(mock_config, mock_core_api, mock_apps_api):
+    # manifiesto de prueba
+    manifest = {
+        "kind": "Deployment",
+        "metadata": {"name": "nginx-deployment", "namespace": "default"}
+    }
+    # configura mock  API
+    mock_api = MagicMock()
+    mock_apps_api.return_value = mock_api
+    # simula que el despliegue ya existe
+    mock_api.read_namespaced_deployment.return_value = manifest
+    # ejecuta funcion
+    resultado = k8s_deploy.apply_manifest(manifest)
+    # verifica resultado
+    assert resultado is True
+    # verifica que se llamo a replace_namespaced_deployment
+    mock_api.replace_namespaced_deployment.assert_called_once_with("nginx-deployment", "default", manifest)
+    # verifica que no se llamo a create
+    mock_api.create_namespaced_deployment.assert_not_called()
+
+
+# test  error al aplicar manifiesto
+@patch("kubernetes.client.AppsV1Api")
+@patch("kubernetes.client.CoreV1Api")
+@patch("kubernetes.config.load_kube_config")
+def test_error_api_al_aplicar_manifest(mock_config, mock_core_api, mock_apps_api):
+    # manifiesto de prueba
+    manifest = {"kind": "Deployment", "metadata": {"name": "nginx-deployment", "namespace": "default"}}
+    # configura mock  error en API
+    mock_api = MagicMock()
+    mock_api.read_namespaced_deployment.side_effect = ApiException(status=500, reason="Server error")
+    mock_apps_api.return_value = mock_api
+    # ejecuta funcion
+    resultado = k8s_deploy.apply_manifest(manifest)
+    # verifica resultado
+    assert resultado is False
+
+
+# test  verificar despliegue listo
+@patch("kubernetes.client.AppsV1Api")
+@patch("kubernetes.config.load_kube_config")
+def test_deployment_listo(mock_config, mock_apps_api):
+    # configura mock  despliegue listo
     mock_deploy = MagicMock()
     mock_deploy.status.ready_replicas = 1
-    mock_deploy.spec.replicas = 3
+    mock_deploy.spec.replicas = 1
     mock_api = MagicMock()
     mock_api.read_namespaced_deployment.return_value = mock_deploy
-    mock_api_class.return_value = mock_api
-    assert k8s_deploy.check_deployment_status("mi-deploy") is False
+    mock_apps_api.return_value = mock_api
+    # ejecuta funcion
+    resultado = k8s_deploy.check_deployment_status("nginx-deployment")
+    # verifica resultado
+    assert resultado is True
 
 
-@patch("src.k8s_deploy.client.AppsV1Api", side_effect=k8s_deploy.ApiException("fallo"))
-@patch("src.k8s_deploy.config.load_kube_config")
-def test_error_leyendo_deployment(mock_config, mock_api_class):
-    assert k8s_deploy.check_deployment_status("error") is False
+# test  verificar despliegue no listo
+@patch("kubernetes.client.AppsV1Api")
+@patch("kubernetes.config.load_kube_config")
+def test_deployment_no_listo(mock_config, mock_apps_api):
+    # configura mock  despliegue no listo
+    mock_deploy = MagicMock()
+    mock_deploy.status.ready_replicas = 0
+    mock_deploy.spec.replicas = 1
+    mock_api = MagicMock()
+    mock_api.read_namespaced_deployment.return_value = mock_deploy
+    mock_apps_api.return_value = mock_api
+    # ejecuta funcion con un solo intento
+    resultado = k8s_deploy.check_deployment_status("nginx-deployment", retries=1, delay=0)
+    # verifica resultado
+    assert resultado is False
 
 
-# tests para flujo completo deploy
+# test  verificar reintentos en despliegue
+@patch("kubernetes.client.AppsV1Api")
+@patch("kubernetes.config.load_kube_config")
+def test_deployment_retry_exitoso(mock_config, mock_apps_api):
+    # configura mock  despliegue inicialmente no listo, luego listo
+    mock_deploy_no_listo = MagicMock()
+    mock_deploy_no_listo.status.ready_replicas = 0
+    mock_deploy_no_listo.spec.replicas = 1
+    mock_deploy_listo = MagicMock()
+    mock_deploy_listo.status.ready_replicas = 1
+    mock_deploy_listo.spec.replicas = 1
+    mock_api = MagicMock()
+    mock_api.read_namespaced_deployment.side_effect = [mock_deploy_no_listo, mock_deploy_listo]
+    mock_apps_api.return_value = mock_api
+    # ejecuta funcion con dos intentos
+    resultado = k8s_deploy.check_deployment_status("nginx-deployment", retries=2, delay=0)
+    # verifica resultado
+    assert resultado is True
+    # verifica que se llamo dos veces a read_namespaced_deployment
+    assert mock_api.read_namespaced_deployment.call_count == 2
+
+
+# test  error al leer despliegue
+@patch("kubernetes.client.AppsV1Api")
+@patch("kubernetes.config.load_kube_config")
+def test_error_leyendo_deployment(mock_config, mock_apps_api):
+    # configura mock  error en API
+    mock_api = MagicMock()
+    mock_api.read_namespaced_deployment.side_effect = ApiException(status=500, reason="Server error")
+    mock_apps_api.return_value = mock_api
+    # ejecuta funcion
+    resultado = k8s_deploy.check_deployment_status("nginx-deployment")
+    # verifica resultado
+    assert resultado is False
+
+
+# test  flujo completo deploy
 @patch("src.k8s_deploy.check_deployment_status", return_value=True)
 @patch("src.k8s_deploy.apply_manifest", return_value=True)
-@patch("src.k8s_deploy.load_manifest", return_value={"metadata": {"name": "test", "namespace": "default"}})
-def test_deploy_exitoso(mock_load, mock_apply, mock_check):
-    resultado = k8s_deploy.deploy("archivo.yaml")
+@patch("src.k8s_deploy.load_manifest", return_value=yaml.safe_load_all(NGINX_YAML))
+def test_deploy_exitoso_multi_documento(mock_load, mock_apply, mock_check):
+    # ejecuta funcion deploy
+    resultado = k8s_deploy.deploy("k8s/nginx-deployment.yaml")
+    # verifica resultado
     assert resultado is True
+    # verifica que apply_manifest se llamo dos veces para Deployment y Service
+    assert mock_apply.call_count == 2

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1,7 +1,6 @@
 import pytest
 import yaml
 import jsonschema
-from jsonschema import validate
 from unittest.mock import patch, mock_open
 from src import workflow_deps
 
@@ -14,19 +13,24 @@ schema = {
             "items": {
                 "type": "object",
                 "properties": {
-                    "event": {"type": "string", "enum": ["file_created", "message_received", "k8s_deploy"]},
+                    "id": {"type": "string"},
+                    "event": {"type": "string", "enum": ["file_created", "message_received"]},
                     "path": {"type": "string"},
                     "queue": {"type": "string"},
-                    "manifest": {"type": "string"},
+                    "action_type": {"type": "string", "enum": ["script", "kubernetes"]},
                     "action": {"type": "string"},
+                    "manifest": {"type": "string"},
+                    "recursive": {"type": "boolean"},
+                    "depends_on": {"type": "array", "items": {"type": "string"}}
                 },
-                "required": ["event", "action"],
+                "required": ["event", "action_type"],
                 "if": {"properties": {"event": {"const": "file_created"}}},
                 "then": {"required": ["path"]},
                 "else": {
                     "if": {"properties": {"event": {"const": "message_received"}}},
                     "then": {"required": ["queue"]}
-                }
+                },
+                "additionalProperties": False
             }
         }
     },
@@ -34,73 +38,123 @@ schema = {
 }
 
 
-def test_cargar_workflows_valido():
-    with open("/app/docs/workflows.yaml") as f:
+# test para cargar workflows validos
+def test_cargar_workflows_valido(tmp_path):
+    # contenido YAML de prueba
+    yaml_content = """
+    workflows:
+      - id: process_file
+        event: file_created
+        path: /app/data
+        action_type: script
+        action: /app/scripts/process_data.sh <file>
+        recursive: false
+      - id: notify_message
+        event: message_received
+        queue: redis://redis:6379/0
+        action_type: script
+        action: python /app/src/notify.py
+      - id: k8s_nginx
+        event: file_created
+        path: /app/data/k8s
+        action_type: kubernetes
+        manifest: /app/k8s/nginx-deployment.yaml
+        depends_on: [process_file]
+    """
+    # crea archivo workflows.yaml de prueba
+    archi = tmp_path / "workflows.yaml"
+    archi.write_text(yaml_content)
+    # carga y valida el YAML
+    with open(archi) as f:
         workflows = yaml.safe_load(f)
-
-    validate(instance=workflows, schema=schema)
+    jsonschema.validate(instance=workflows, schema=schema)
+    # verifica que se cargaron correctamente
     assert len(workflows["workflows"]) == 3
-    assert workflows["workflows"][2]["event"] == "k8s_deploy"
-    assert "<manifest>" in workflows["workflows"][2]["action"]
-    assert "manifest" in workflows["workflows"][2]
+    assert workflows["workflows"][0]["recursive"] is False
+    assert workflows["workflows"][2]["action_type"] == "kubernetes"
+    assert workflows["workflows"][2]["manifest"] == "/app/k8s/nginx-deployment.yaml"
 
 
+# test para cargar workflows invalidos
 def test_cargar_workflows_invalido():
+    # contenido YAML invalido
     invalid_yaml = """
     workflows:
       - event: invalid_event
+        action_type: script
         action: echo test
     """
+    # verifica que se lanza error de validacion
     with pytest.raises(jsonschema.ValidationError):
-        validate(instance=yaml.safe_load(invalid_yaml), schema=schema)
+        jsonschema.validate(instance=yaml.safe_load(invalid_yaml), schema=schema)
 
 
 # test para init_state
 @patch("os.path.exists", return_value=False)
 @patch("builtins.open", new_callable=mock_open)
 def test_init_state_crea_archivo(mock_open_func, mock_exists):
+    # ejecuta funcion
     workflow_deps.init_state()
+    # verifica que se creo el archivo
     mock_open_func.assert_called_once_with("/app/data/workflow_state.json", 'w')
+    # verifica que se escribio JSON vacio
     handle = mock_open_func()
-    handle.write.assert_called_once_with("{}")  # Se escribe un JSON vacío
+    handle.write.assert_called_once_with("{}")
 
 
 # test para update_workflow_state
 @patch("os.path.exists", return_value=True)
 @patch("builtins.open", new_callable=mock_open, read_data='{}')
 def test_update_workflow_state_agrega_estado(mock_open_func, mock_exists):
+    # ejecuta funcion
     workflow_deps.update_workflow_state("workflow1", "success")
+    # verifica que se abrio el archivo
     calls = mock_open_func.call_args_list
     assert calls[0][0][0] == "/app/data/workflow_state.json"
+    # verifica que se escribio algo
     handle = mock_open_func()
-    handle.write.assert_called()  # Confirmamos que se escribió algo
+    handle.write.assert_called()
 
 
 # test para check_dependencies: sin dependencias
 def test_check_dependencies_sin_dependencias():
+    # ejecuta funcion sin dependencias
     resultado = workflow_deps.check_dependencies({"id": "1", "event": "x"})
+    # verifica resultado
     assert resultado is True
 
 
 # test para check_dependencies: con dependencias cumplidas
 @patch("os.path.exists", return_value=True)
-@patch("builtins.open", new_callable=mock_open, read_data='{"dep1": "success"}')
+@patch("builtins.open", new_callable=mock_open, read_data='{"dep1": "success", "dep2": "success"}')
 def test_check_dependencies_con_dependencias_ok(mock_open_func, mock_exists):
-    workflow = {"depends_on": ["dep1"]}
-    assert workflow_deps.check_dependencies(workflow) is True
+    # flujo con multiples dependencias
+    workflow = {"depends_on": ["dep1", "dep2"]}
+    # ejecuta funcion
+    resultado = workflow_deps.check_dependencies(workflow)
+    # verifica resultado
+    assert resultado is True
 
 
 # test para check_dependencies: con dependencias fallidas
 @patch("os.path.exists", return_value=True)
 @patch("builtins.open", new_callable=mock_open, read_data='{"dep1": "failed"}')
 def test_check_dependencies_con_dependencias_fallidas(mock_open_func, mock_exists):
+    # flujo con dependencia fallida
     workflow = {"depends_on": ["dep1"]}
-    assert workflow_deps.check_dependencies(workflow) is False
+    # ejecuta funcion
+    resultado = workflow_deps.check_dependencies(workflow)
+    # verifica resultado
+    assert resultado is False
 
 
 # test para check_dependencies: error al leer archivo
 @patch("os.path.exists", return_value=True)
 @patch("builtins.open", side_effect=Exception("Falla al leer"))
 def test_check_dependencies_con_error(mock_open_func, mock_exists):
+    # flujo con dependencia
     workflow = {"depends_on": ["dep1"]}
-    assert workflow_deps.check_dependencies(workflow) is False
+    # ejecuta funcion
+    resultado = workflow_deps.check_dependencies(workflow)
+    # verifica resultado
+    assert resultado is False


### PR DESCRIPTION
Se agrego y actualizo los tests para:

- `workflow_deps.py`
- `k8s_deploy.py`
- `event_engine.py`

Se valido la cobertura >80%
Cumpliendo con el Issue #30 
Los test se organizaron de esta manera:

- test_cargar_workflows.py::test_cargar_workflows_valido                   
- test_cargar_workflows.py::test_cargar_workflows_faltante                      
- test_cargar_workflows.py::test_cargar_workflows_invalido                      
- test_k8s_deploy.py::test_carga_manifest_correctamente                         
- test_k8s_deploy.py::test_error_manifest_no_encontrado                         
- test_k8s_deploy.py::test_error_yaml_invalido                                  
- test_k8s_deploy.py::test_aplica_manifest_deployment                           
- test_k8s_deploy.py::test_aplica_manifest_service                              
- test_k8s_deploy.py::test_aplica_manifest_deployment_existente                 
- test_k8s_deploy.py::test_error_api_al_aplicar_manifest                        
- test_k8s_deploy.py::test_deployment_listo                                     
- test_k8s_deploy.py::test_deployment_no_listo                                  
- test_k8s_deploy.py::test_deployment_retry_exitoso                             
- test_k8s_deploy.py::test_error_leyendo_deployment                             
- test_k8s_deploy.py::test_deploy_exitoso_multi_documento                       
- test_listen_redis.py::test_escuchar_redis_valido                              
- test_listen_redis.py::test_escuchar_redis_error                               
- test_manejar_eventos_archivos.py::test_manejador_eventos_archivo_valido_script
- test_manejar_eventos_archivos.py::test_manejador_eventos_recursive_false      
- test_notify.py::test_notificar_mensaje_valido                                 
- test_notify.py::test_notificar_mensaje_default                                
- test_workflows.py::test_cargar_workflows_valido                               
- test_workflows.py::test_cargar_workflows_invalido                             
- test_workflows.py::test_init_state_crea_archivo                               
- test_workflows.py::test_update_workflow_state_agrega_estado                   
- test_workflows.py::test_check_dependencies_sin_dependencias                   
- test_workflows.py::test_check_dependencies_con_dependencias_ok                
- test_workflows.py::test_check_dependencies_con_dependencias_fallidas          
- test_workflows.py::test_check_dependencies_con_error      
